### PR TITLE
Add missing salespoint plugin repository

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -362,10 +362,17 @@
 	</repositories>
 
 	<pluginRepositories>
+
 		<pluginRepository>
 			<id>spring-libs-milestone</id>
-			<url>http://repo.spring.io/libs-milestone</url>
+			<url>https://repo.spring.io/libs-milestone</url>
 		</pluginRepository>
+
+		<pluginRepository>
+			<id>salespointframework</id>
+			<url>https://www.st.inf.tu-dresden.de/SalesPoint/repository</url>
+		</pluginRepository>
+
 	</pluginRepositories>
 
 </project>


### PR DESCRIPTION
The `salespointframeowork` repository must be specified again as a plugin repository, otherwise Maven won't be able to resolve the `st-lab-resources` artifact when using the `ci` profile.

For the exact error message that is fixed, take a look https://travis-ci.org/st-tu-dresden/videoshop/builds/454916991#L2782 for example, which is a Travis build of the videoshop which applies the `ci` profile:

```
[ERROR] Failed to execute goal com.buschmais.jqassistant:jqassistant-maven-plugin:1.4.0:scan (default) on project videoshop: Execution default of goal com.buschmais.jqassistant:jqassistant-maven-plugin:1.4.0:scan failed: Plugin com.buschmais.jqassistant:jqassistant-maven-plugin:1.4.0 or one of its dependencies could not be resolved: Could not find artifact de.tudresden.inf.st.lab:st-lab-resources:jar:2.0.0.RELEASE in spring-libs-milestone (http://repo.spring.io/libs-milestone) -> [Help 1]
```

Please note that this is not urgent. To be able to use `mvn -Pci ...` in our lab infrastructure, I worked around the problem with a special profile in `$HOME/.m2/settings.xml` :-)

This fix should also be applied to the `2.0.x` branch.